### PR TITLE
Improve map imagery square presentation

### DIFF
--- a/wp-content/plugins/cv-dossier-context/css/cv-dossier.css
+++ b/wp-content/plugins/cv-dossier-context/css/cv-dossier.css
@@ -336,12 +336,15 @@
     border-radius: 8px;
     overflow: hidden;
     margin-bottom: 8px;
+    aspect-ratio: 1 / 1;
+    position: relative;
 }
 
 .cv-map-popup-image img {
     display: block;
     width: 100%;
-    height: auto;
+    height: 100%;
+    object-fit: cover;
     transition: transform 0.25s ease;
     cursor: zoom-in;
 }
@@ -395,10 +398,10 @@
 }
 
 .cv-map-lightbox__inner img {
-    width: 100%;
+    width: auto;
     height: auto;
-    max-height: 100vh;
-    max-width: min(90vw, 960px);
+    max-width: min(70vw, 70vh, 720px);
+    max-height: min(70vw, 70vh, 720px);
     object-fit: contain;
     border-radius: 12px;
     box-shadow: 0 10px 40px rgba(0,0,0,0.4);


### PR DESCRIPTION
## Summary
- enforce square cropping for map popup thumbnails so they better accommodate square imagery
- limit lightbox dimensions using a square-friendly viewport cap to avoid oversized displays

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd319e53b4832fbaf077e1c025af55