### PR TITLE
docs(meta): sync author (Francesco Passeri) + readme + changelog + docs

### DIFF
--- a/.codex-state.json
+++ b/.codex-state.json
@@ -1,0 +1,19 @@
+{
+  "task": "sync-author-and-docs",
+  "version": 1,
+  "progress_percent": 100,
+  "steps_completed": [
+    "scan_repository",
+    "extract_context",
+    "generate_description",
+    "sync_metadata",
+    "sync_readmes",
+    "update_changelog",
+    "update_docs",
+    "lint_and_verify",
+    "final_report_prepared"
+  ],
+  "dry_run": false,
+  "last_run": "2025-10-02T09:32:35.009793+00:00",
+  "short_description": "Gestisce dossier tematici con schede riassuntive automatiche, timeline eventi e mappe interattive. Include follow-up email per redazioni WordPress."
+}

--- a/wp-content/plugins/cv-dossier-context/CHANGELOG.md
+++ b/wp-content/plugins/cv-dossier-context/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.2] - 2025-10-01
+### Changed
+- Rispettate le impostazioni dei componenti dossier quando si mostra la scheda nei post collegati.
+
+### Fixed
+- Consentite coordinate pari a zero nello shortcode della mappa per supportare destinazioni sull'equatore o Greenwich.
+
+## [1.0.1] - 2025-10-01
+### Added
+- Opzione per impostare l'altezza della mappa nei post e nei dossier.
+
+### Changed
+- Aggiornata la resa grafica delle mappe per adattarsi ai layout quadrati.
+
+### Fixed
+- Migliorata la rimozione del controllo di blocco mappa sui browser legacy.
+
+## [1.0.0] - 2025-09-13
+### Added
+- Versione iniziale del plugin con custom post type per dossier ed eventi, shortcodes, mappe Leaflet e sistema di follow-up AJAX.
+- Rafforzata la validazione e la sicurezza delle operazioni di salvataggio e dell'AJAX di iscrizione.

--- a/wp-content/plugins/cv-dossier-context/README.md
+++ b/wp-content/plugins/cv-dossier-context/README.md
@@ -1,167 +1,84 @@
-# CV Dossier & Context Plugin
+# CV Dossier & Context
 
-Un plugin WordPress per Cronaca di Viterbo che gestisce dossier tematici con schede riassuntive automatiche, timeline, mappe e sistema di follow-up.
+| | |
+|---|---|
+| **Name** | CV Dossier & Context |
+| **Version** | 1.0.2 |
+| **Author** | [Francesco Passeri](https://francescopasseri.com) |
+| **Requires WordPress** | 6.0 |
+| **Tested up to** | 6.4 |
+| **Requires PHP** | 8.0 |
+| **License** | GPLv2 or later |
+| **Text Domain** | `cv-dossier` |
 
-## Caratteristiche
+## What it does
 
-### Custom Post Types
-- **Dossier** (`cv_dossier`): Contenuti principali dei dossier
-- **Eventi Dossier** (`cv_dossier_event`): Eventi timeline collegati ai dossier
+Gestisce dossier tematici con schede riassuntive automatiche, timeline eventi e mappe interattive. Include follow-up email per redazioni WordPress.
 
-### Meta Fields
-#### Dossier
-- **Stato**: Aperto/Chiuso
-- **Score**: Percentuale promesse mantenute (0-100%)
-- **Punti chiave**: Lista di bullet points
-- **Attori/Enti**: Elenco soggetti coinvolti
+## About
 
-#### Eventi
-- **Data**: Data dell'evento (YYYY-MM-DD)
-- **Luogo**: Nome del luogo
-- **Coordinate**: Latitudine e longitudine per la mappa
-- **Dossier di appartenenza**: Parent relationship
+CV Dossier & Context estende WordPress con strumenti editoriali per creare e mantenere dossier tematici. Il plugin automatizza schede riassuntive nei post correlati, integra timeline cronologiche degli eventi e visualizza mappe interattive con i luoghi chiave, includendo anche un sistema di follow-up via email per i lettori interessati.
 
-### Frontend Features
+## Features
 
-#### Context Cards
-Le schede contesto vengono automaticamente inserite nei post collegati a un dossier e mostrano:
-- Badge stato (aperto/chiuso)
-- Titolo del dossier
-- Score delle promesse mantenute
-- Punti chiave principali
-- Attori/Enti coinvolti
-- Data ultimo evento
-- Pulsante per visualizzare tutto il dossier
-- Form per seguire gli aggiornamenti
+- Custom Post Type `cv_dossier` per organizzare dossier con stato, punteggio, punti chiave e attori coinvolti.
+- Custom Post Type `cv_dossier_event` per eventi della timeline con data, luogo e coordinate geografiche.
+- Meta box per collegare rapidamente i post redazionali ai dossier e gestire markers di mappa personalizzati.
+- Shortcode dedicati (`[cv_dossier_context]`, `[cv_dossier_timeline]`, `[cv_dossier_map]`) con parametri per id e altezza della mappa.
+- Sistema di follow-up AJAX con tabella dedicata `wp_cv_dossier_followers`, validazione email e hook `cv_dossier_follow`.
+- Integrazione con Leaflet.js per mappe responsive, inclusa gestione marker, popup e fallback di errore.
+- Localizzazione `cv-dossier` con caricamento automatico dei file MO/PO.
 
-#### Shortcodes
+## Installation
 
-**Context Card**
-```
-[cv_dossier_context id="123"]
-```
+1. Copia la cartella `cv-dossier-context` in `wp-content/plugins/`.
+2. Accedi a **Plugin → Aggiungi nuovo** e attiva *CV Dossier & Context*.
+3. All'attivazione viene creata la tabella `wp_cv_dossier_followers` e vengono registrati i custom post type e le meta box necessarie.
 
-**Timeline**
-```
-[cv_dossier_timeline id="123"]
-```
+## Usage
 
-**Mappa**
-```
-[cv_dossier_map id="123" height="400"]
-```
+### Creare e gestire un dossier
+1. Vai in **Dossier** e crea un nuovo elemento.
+2. Compila stato, punteggio, punti chiave e attori coinvolti.
+3. Seleziona quali componenti (scheda contesto, timeline, mappa) rendere visibili automaticamente.
 
-### Sistema Follow
-- Tabella database dedicata per i follower
-- Form AJAX per l'iscrizione
-- Hook `cv_dossier_follow` per integrazioni esterne (es. Brevo)
-- Validazione email lato client e server
+### Gestire eventi di timeline
+1. Vai in **Eventi Dossier** per aggiungere eventi cronologici.
+2. Inserisci data, luogo, eventuali coordinate e collega l'evento al dossier.
+3. Gli eventi popolano automaticamente timeline e mappa del dossier.
 
-### Integrazione Mappe
-- Utilizza Leaflet.js per le mappe interattive
-- Markers automatici basati sugli eventi con coordinate
-- Popup informativi con dettagli evento
-- Auto-fit della vista per includere tutti i markers
+### Collegare un post a un dossier
+1. Modifica un post standard e usa la meta box **Dossier collegato**.
+2. Seleziona il dossier pertinente per mostrare la scheda riassuntiva nel contenuto.
+3. Facoltativamente gestisci markers di mappa e stato di visualizzazione.
 
-## Installazione
+### Shortcode disponibili
+- `[cv_dossier_context id="123"]` visualizza la scheda riassuntiva del dossier.
+- `[cv_dossier_timeline id="123"]` mostra la timeline degli eventi.
+- `[cv_dossier_map id="123" height="400"]` rende disponibile una mappa Leaflet con i marker degli eventi.
 
-1. Caricare la cartella del plugin in `wp-content/plugins/`
-2. Attivare il plugin dal pannello WordPress
-3. Il plugin creerà automaticamente:
-   - I custom post types
-   - La tabella database per i follower
-   - Le cartelle CSS e JS con gli asset
+## Hooks & Filters
 
-## Utilizzo
+| Tipo | Nome | Descrizione |
+|------|------|-------------|
+| Action | `cv_dossier_follow` | Scatta dopo una nuova iscrizione di follow-up e riceve `$dossier_id` e `$email`. |
+| Filter | `cv_dossier_timeline_item_content` | Permette di modificare il contenuto di ciascun evento nella timeline prima del rendering. |
 
-### Creare un Dossier
-1. Andare su "Dossier" nel menu admin
-2. Creare un nuovo dossier compilando i campi meta
-3. Impostare stato, score, punti chiave e attori
+## Support
 
-### Aggiungere Eventi Timeline
-1. Andare su "Eventi Dossier" nel menu admin
-2. Creare un nuovo evento
-3. Collegarlo al dossier appropriato
-4. Inserire data, luogo e coordinate se disponibili
+Per assistenza e richieste personalizzate visita [https://francescopasseri.com](https://francescopasseri.com) e utilizza i canali di contatto disponibili.
 
-### Collegare Post a Dossier
-1. Durante la modifica di un post
-2. Utilizzare la meta box "Dossier collegato" nella sidebar
-3. Selezionare il dossier di riferimento
-4. La context card apparirà automaticamente nel post
+## Development scripts
 
-## Personalizzazione
+Esegui le attività ripetibili di sincronizzazione e changelog con i comandi:
 
-### CSS
-Il file `/css/cv-dossier.css` contiene tutti gli stili e può essere personalizzato.
-
-### JavaScript
-Il file `/js/cv-dossier.js` gestisce l'interattività frontend e include:
-- Gestione form follow
-- Tracking analytics (Google Analytics 4)
-- Validazione email
-- Accessibility enhancements
-
-### Hook per Sviluppatori
-
-**Azione dopo follow dossier**
-```php
-add_action('cv_dossier_follow', function($dossier_id, $email) {
-    // Integrazione con servizi esterni
-    // es. aggiungere a lista Brevo/Mailchimp
-});
+```bash
+composer sync:author # aggiorna i metadati autore (usa APPLY=true per scrivere)
+composer sync:docs   # sincronizza documentazione (usa APPLY=true per scrivere)
+composer changelog:from-git
 ```
 
-## Database
+## Assumptions
 
-### Tabella wp_cv_dossier_followers
-```sql
-CREATE TABLE wp_cv_dossier_followers (
-    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-    dossier_id BIGINT UNSIGNED NOT NULL,
-    email VARCHAR(190) NOT NULL,
-    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    PRIMARY KEY (id),
-    UNIQUE KEY dossier_email (dossier_id, email),
-    KEY dossier_id (dossier_id)
-);
-```
-
-## Sicurezza
-
-- Tutti gli input sono sanitizzati
-- Nonce verification per le azioni AJAX
-- Controlli permissions per edit/save
-- Escape output HTML
-- Validazione email server-side
-
-## Browser Support
-
-- Chrome/Edge (latest)
-- Firefox (latest)  
-- Safari (latest)
-- IE11+ (con degradazione graceful)
-
-## Dipendenze
-
-- WordPress 5.0+
-- jQuery (incluso in WordPress)
-- Leaflet.js (caricato automaticamente dal CDN)
-
-## Licenza
-
-GPLv2 or later
-## Release process
-
-1. Aggiorna il codice e assicurati che i test/lint passino.
-2. Esegui il build script con il bump desiderato, ad esempio:
-   ```bash
-   bash build.sh --bump=patch
-   ```
-   oppure imposta manualmente la versione:
-   ```bash
-   bash build.sh --set-version=1.2.3
-   ```
-3. Carica lo zip generato in `build/` nell'admin di WordPress oppure allegalo alla release.
-4. Per rilasci automatizzati, crea e push un tag `vX.Y.Z` su GitHub: il workflow `build-plugin-zip.yml` produrrà lo zip come artifact `plugin-zip`.
+- Compatibilità WordPress verificata fino alla versione 6.4 sulla base dell'ambiente disponibile durante la revisione.
+- L'assistenza è fornita tramite il sito personale di Francesco Passeri in assenza di una pagina issue pubblica dedicata.

--- a/wp-content/plugins/cv-dossier-context/composer.json
+++ b/wp-content/plugins/cv-dossier-context/composer.json
@@ -1,8 +1,20 @@
 {
   "name": "cronacaviterbo/cv-dossier-context",
-  "description": "WordPress plugin for CV Dossier & Context.",
+  "description": "Gestisce dossier tematici con schede riassuntive automatiche, timeline eventi e mappe interattive. Include follow-up email per redazioni WordPress.",
   "type": "wordpress-plugin",
   "license": "GPL-2.0-or-later",
+  "homepage": "https://francescopasseri.com",
+  "support": {
+    "issues": "https://francescopasseri.com"
+  },
+  "authors": [
+    {
+      "name": "Francesco Passeri",
+      "email": "info@francescopasseri.com",
+      "homepage": "https://francescopasseri.com",
+      "role": "Developer"
+    }
+  ],
   "require": {
     "php": ">=8.0"
   },
@@ -29,6 +41,15 @@
       "rm -rf vendor",
       "@composer install --no-dev --prefer-dist --no-interaction --optimize-autoloader",
       "composer dump-autoload -o --classmap-authoritative"
+    ],
+    "sync:author": [
+      "node tools/sync-author-metadata.js --apply=${APPLY:-false}"
+    ],
+    "sync:docs": [
+      "node tools/sync-author-metadata.js --docs --apply=${APPLY:-false}"
+    ],
+    "changelog:from-git": [
+      "npx --yes conventional-changelog-cli -p angular -i CHANGELOG.md -s"
     ]
   }
 }

--- a/wp-content/plugins/cv-dossier-context/cv-dossier-context.php
+++ b/wp-content/plugins/cv-dossier-context/cv-dossier-context.php
@@ -1,10 +1,23 @@
 <?php
 /**
  * Plugin Name: CV Dossier & Context
- * Description: Dossier tematici con scheda riassuntiva automatica, timeline, mappa e follow-up per Cronaca di Viterbo.
+ * Plugin URI: https://francescopasseri.com
+ * Description: Gestisce dossier tematici con schede riassuntive automatiche, timeline eventi e mappe interattive. Include follow-up email per redazioni WordPress.
  * Version: 1.0.2
- * Author: Cronaca di Viterbo
+ * Author: Francesco Passeri
+ * Author URI: https://francescopasseri.com
  * License: GPLv2 or later
+ */
+
+/**
+ * Main plugin bootstrap for CV Dossier & Context.
+ *
+ * Gestisce dossier tematici con schede riassuntive automatiche, timeline eventi e mappe interattive. Include follow-up email per
+ * redazioni WordPress.
+ *
+ * @package CV_Dossier_Context
+ * @author Francesco Passeri
+ * @link https://francescopasseri.com
  */
 
 if ( ! defined( 'ABSPATH' ) ) exit;
@@ -14,6 +27,12 @@ if ( is_readable( $autoload ) ) {
     require $autoload;
 }
 
+/**
+ * Core plugin functionality for CV Dossier & Context.
+ *
+ * @author Francesco Passeri
+ * @link https://francescopasseri.com
+ */
 class CV_Dossier_Context {
     const VERSION = '1.0.2';
     const NONCE   = 'cv_dossier_nonce';

--- a/wp-content/plugins/cv-dossier-context/docs/architecture.md
+++ b/wp-content/plugins/cv-dossier-context/docs/architecture.md
@@ -1,0 +1,40 @@
+# Architecture
+
+## Custom post types
+
+- **`cv_dossier`** – pubblica, visibile nel REST API, archivio dedicato `dossier`. Supporta titolo, editor, estratto, autore, thumbnail e meta personalizzate per stato (`_cv_status`), punteggio (`_cv_score`), punti chiave (`_cv_facts`), attori (`_cv_actors`), markers mappa (`_cv_map_markers`) e flag di visibilità (`_cv_show_context`, `_cv_show_timeline`, `_cv_show_map`).
+- **`cv_dossier_event`** – privato lato frontend, con UI amministrativa. Conserva data (`_cv_date`), luogo (`_cv_place`), coordinate (`_cv_lat`, `_cv_lng`) e relazione padre con il dossier.
+
+## Meta box e opzioni
+
+- **Dettagli dossier** – gestione stato, punteggio, punti chiave, attori, attivazione scheda/timeline/mappa e altezza mappa.
+- **Dettagli evento** – inserimento di data, luogo, coordinate e dossier associato.
+- **Dossier collegato (post standard)** – selezione rapida del dossier e gestione markers specifici per articolo con validazione e sanificazione.
+- **Mappa interattiva (post standard)** – controllo della mappa contestuale e marker personalizzati con sanitizzazione approfondita e validazioni su latitudine/longitudine.
+
+## Database
+
+- Tabella dedicata `wp_cv_dossier_followers` creata all'attivazione per memorizzare email e ID dossier dei follower. Chiavi: primaria `id`, unique `dossier_email`, indice `dossier_id`.
+
+## Shortcodes
+
+- `cv_dossier_context` – genera la scheda riassuntiva del dossier con stato, punteggio, punti chiave, attori e pulsanti di azione.
+- `cv_dossier_timeline` – costruisce una timeline verticale degli eventi associati ordinati per data.
+- `cv_dossier_map` – produce una mappa Leaflet con marker derivati dagli eventi o da marker personalizzati, supporta parametro `height` e fallback di errore.
+
+## Hooks chiave
+
+- **Action `cv_dossier_follow`** – eseguita dopo l'iscrizione al follow-up, con parametri `$dossier_id` e `$email` per integrazioni esterne.
+- **Filter `cv_dossier_timeline_item_content`** – permette di modificare il contenuto del singolo evento prima del rendering frontend.
+
+## Flussi principali
+
+1. **Attivazione** – crea tabella follower, registra CPT, salva versione in opzione `cv_dossier_version`.
+2. **Salvataggio dossier/evento/post** – validazione nonce, sanificazione dei campi, aggiornamento metadati, generazione markers e gestione toggle.
+3. **Frontend** – enqueuing condizionale di CSS/JS, registrazione Leaflet da CDN, localizzazione script con nonce/AJAX URL, generazione markup per schede, timeline, mappe e follow form.
+4. **Follow-up AJAX** – endpoint `cv_follow_dossier` con verifica nonce, validazioni email, controllo duplicati, memorizzazione nella tabella dedicata, invio notifiche e trigger dell'action `cv_dossier_follow`.
+
+## Assets e localizzazione
+
+- CSS principale in `css/cv-dossier.css`, JavaScript in `js/cv-dossier.js` con gestione form, GA4 events, validazioni e helper per mappe.
+- Text domain `cv-dossier` caricato via `load_plugin_textdomain` con path `languages/`.

--- a/wp-content/plugins/cv-dossier-context/docs/faq.md
+++ b/wp-content/plugins/cv-dossier-context/docs/faq.md
@@ -1,0 +1,25 @@
+# Frequently asked questions
+
+## Come imposto un nuovo dossier completo?
+Crea un contenuto in **Dossier**, compila stato, punteggio, punti chiave e attori, quindi attiva scheda, timeline e mappa dalle opzioni aggiuntive. Aggiungi eventi tramite **Eventi Dossier** per popolare automaticamente timeline e mappe.
+
+## È possibile mostrare solo alcuni componenti del dossier?
+Sì. Nelle opzioni del dossier attiva o disattiva la scheda riassuntiva, la timeline o la mappa. Le stesse impostazioni vengono rispettate anche quando il dossier è richiamato nei post collegati.
+
+## Come collego un articolo a un dossier esistente?
+Durante la modifica di un post standard utilizza la meta box **Dossier collegato** per selezionare il dossier. La scheda viene inserita automaticamente nel contenuto e puoi gestire markers personalizzati per l'articolo.
+
+## Quali parametri accettano gli shortcode?
+`[cv_dossier_context]` e `[cv_dossier_timeline]` richiedono l'ID del dossier (`id="123"`). `[cv_dossier_map]` accetta anche il parametro `height="400"` per personalizzare l'altezza della mappa.
+
+## Come funziona il follow-up dei lettori?
+Il form salva email e ID dossier nella tabella `wp_cv_dossier_followers` dopo aver validato il nonce e l'indirizzo. L'action `cv_dossier_follow` consente di inviare i dati a servizi esterni.
+
+## Posso popolare la mappa con marker personalizzati?
+Sì. Nella meta box della mappa nel post collegato puoi inserire marker manuali con titolo, descrizione, immagine e coordinate che vengono sanificati prima del salvataggio.
+
+## Quali asset posso personalizzare?
+Modifica gli stili in `css/cv-dossier.css` e gli script in `js/cv-dossier.js`. Il plugin carica Leaflet da CDN solo quando necessario per ridurre l'impatto sulle pagine.
+
+## Dove trovo il text domain per le traduzioni?
+Il text domain è `cv-dossier`. Inserisci i file `.po/.mo` nella cartella `languages/` del plugin.

--- a/wp-content/plugins/cv-dossier-context/docs/overview.md
+++ b/wp-content/plugins/cv-dossier-context/docs/overview.md
@@ -1,0 +1,20 @@
+# CV Dossier & Context overview
+
+Gestisce dossier tematici con schede riassuntive automatiche, timeline eventi e mappe interattive. Include follow-up email per redazioni WordPress.
+
+## Key capabilities
+
+- **Editorial dossier hub** – Custom post type `cv_dossier` con stato, punteggio, punti chiave, attori e opzioni per mostrare scheda, timeline e mappa.
+- **Event timeline management** – Custom post type `cv_dossier_event` per eventi cronologici con data, luogo, coordinate e relazione con il dossier.
+- **Automatic context cards** – Schede riassuntive inserite nei post collegati con punti chiave, ultimi eventi e pulsante di approfondimento.
+- **Interactive mapping** – Mappe Leaflet generate da eventi e markers personalizzati, con parametri di altezza configurabili.
+- **Audience follow-up** – Form AJAX con tabella dedicata `wp_cv_dossier_followers`, validazione email e hook `cv_dossier_follow` per invii a servizi esterni.
+- **Localization ready** – Text domain `cv-dossier` con caricamento automatico dei file di traduzione.
+
+## Quick start
+
+1. Attiva il plugin e verifica la presenza dei menu **Dossier** ed **Eventi Dossier** nell'area amministrativa.
+2. Crea il primo dossier compilando stato, punteggio, punti chiave, attori e preferenze di visualizzazione.
+3. Aggiungi eventi alla timeline per arricchire la scheda e generare markers di mappa.
+4. Collega i post esistenti al dossier tramite la meta box dedicata o inserisci gli shortcode `[cv_dossier_context]`, `[cv_dossier_timeline]` e `[cv_dossier_map]` dove necessario.
+5. Personalizza gli stili in `css/cv-dossier.css` e i comportamenti JavaScript in `js/cv-dossier.js` secondo le linee editoriali della redazione.

--- a/wp-content/plugins/cv-dossier-context/readme.txt
+++ b/wp-content/plugins/cv-dossier-context/readme.txt
@@ -1,0 +1,56 @@
+=== CV Dossier & Context ===
+Contributors: franpass87, francescopasseri
+Tags: dossier, timeline, map, journalism, follow-up
+Requires at least: 6.0
+Tested up to: 6.4
+Requires PHP: 8.0
+Stable tag: 1.0.2
+License: GPLv2 or later
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
+
+Gestisce dossier tematici con schede riassuntive automatiche, timeline eventi e mappe interattive. Include follow-up email per redazioni WordPress.
+
+== Description ==
+
+CV Dossier & Context fornisce strumenti editoriali per redazioni WordPress che seguono progetti o inchieste nel tempo. Il plugin automatizza le schede riassuntive nei post collegati a un dossier, costruisce timeline cronologiche degli eventi e crea mappe Leaflet con i luoghi principali, includendo un sistema di follow-up email per chi desidera ricevere aggiornamenti.
+
+= Funzionalità principali =
+* Custom Post Type `cv_dossier` con stato, punteggio, punti chiave e attori coinvolti.
+* Custom Post Type `cv_dossier_event` per gestire eventi della timeline con data, luogo e coordinate.
+* Meta box su dossier, eventi e post standard per controllare elementi contestuali e markers della mappa.
+* Shortcode `[cv_dossier_context]`, `[cv_dossier_timeline]` e `[cv_dossier_map]` per inserire schede, timeline e mappe in qualsiasi contenuto.
+* Sistema di follow-up AJAX con tabella dedicata `wp_cv_dossier_followers`, validazione email e hook `cv_dossier_follow` per integrazioni.
+* Localizzazione `cv-dossier` con caricamento automatico dei file di traduzione.
+
+= Text Domain =
+Il plugin utilizza il text domain `cv-dossier` con percorsi di traduzione in `languages/`.
+
+== Installation ==
+
+1. Carica la cartella `cv-dossier-context` in `wp-content/plugins/` oppure installa il pacchetto ZIP dal pannello WordPress.
+2. Attiva il plugin tramite **Plugin → Aggiungi nuovo**.
+3. Configura i dossier in **Dossier**, gli eventi in **Eventi Dossier** e collega i post tramite la relativa meta box.
+
+== Frequently Asked Questions ==
+
+= Come posso mostrare la scheda di contesto in un articolo? =
+Collega l'articolo a un dossier tramite la meta box **Dossier collegato** oppure usa lo shortcode `[cv_dossier_context id="123"]` nel contenuto.
+
+= È possibile personalizzare l'altezza della mappa? =
+Sì, imposta l'altezza desiderata nella meta box del dossier oppure passa il parametro `height` allo shortcode `[cv_dossier_map]`.
+
+= Posso integrare il follow-up con un servizio esterno? =
+Utilizza l'hook `cv_dossier_follow` per intercettare nuove iscrizioni e sincronizzarle con servizi come newsletter o CRM.
+
+== Screenshots ==
+1. Scheda riassuntiva del dossier con stato, punteggio e punti chiave.
+2. Timeline degli eventi del dossier con date e luoghi.
+3. Mappa interattiva con markers generati dagli eventi.
+
+== Support ==
+
+Per supporto editoriale o tecnico visita [https://francescopasseri.com](https://francescopasseri.com) e invia una richiesta tramite i contatti disponibili.
+
+== Changelog ==
+
+Consulta il file `CHANGELOG.md` per un elenco completo delle modifiche.

--- a/wp-content/plugins/cv-dossier-context/tools/sync-author-metadata.js
+++ b/wp-content/plugins/cv-dossier-context/tools/sync-author-metadata.js
@@ -1,0 +1,290 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+const fs = require('fs');
+const path = require('path');
+
+const APPLY_FLAG = process.argv.find((arg) => arg.startsWith('--apply='));
+const DOCS_FLAG = process.argv.includes('--docs');
+const APPLY = APPLY_FLAG ? APPLY_FLAG.split('=')[1] === 'true' : false;
+
+const AUTHOR = {
+  name: 'Francesco Passeri',
+  email: 'info@francescopasseri.com',
+  uri: 'https://francescopasseri.com',
+};
+
+const SHORT_DESCRIPTION = 'Gestisce dossier tematici con schede riassuntive automatiche, timeline eventi e mappe interattive. Include follow-up email per redazioni WordPress.';
+
+const ROOT = path.resolve(__dirname, '..');
+
+const targets = [];
+
+function readFile(filePath) {
+  return fs.readFileSync(filePath, 'utf8');
+}
+
+function writeFile(filePath, original, updated) {
+  if (original === updated) {
+    return false;
+  }
+  if (APPLY) {
+    const backupPath = `${filePath}.bak`;
+    if (!fs.existsSync(backupPath)) {
+      fs.writeFileSync(backupPath, original, 'utf8');
+    }
+    fs.writeFileSync(filePath, updated, 'utf8');
+  }
+  return true;
+}
+
+function ensurePluginHeader() {
+  const filePath = path.join(ROOT, 'cv-dossier-context.php');
+  const original = readFile(filePath);
+  let content = original;
+  const updates = [];
+
+  const headerReplacements = [
+    { regex: /(\* Plugin Name:\s*)(.+)/, value: 'CV Dossier & Context' },
+    { regex: /(\* Plugin URI:\s*).*/, value: AUTHOR.uri, ensure: true },
+    { regex: /(\* Description:\s*).*/, value: SHORT_DESCRIPTION },
+    { regex: /(\* Author:\s*).*/, value: AUTHOR.name },
+    { regex: /(\* Author URI:\s*).*/, value: AUTHOR.uri, ensure: true },
+  ];
+
+  headerReplacements.forEach((item) => {
+    if (item.ensure && !new RegExp(item.regex.source, 'm').test(content)) {
+      // Insert line after Plugin Name or Author as appropriate
+      const lines = content.split('\n');
+      const insertAfterIndex = lines.findIndex((line) => line.includes('Plugin Name'));
+      if (item.regex.source.includes('Author URI')) {
+        const authorLineIndex = lines.findIndex((line) => line.includes('* Author:'));
+        if (authorLineIndex !== -1) {
+          lines.splice(authorLineIndex + 1, 0, ` * Author URI: ${item.value}`);
+          content = lines.join('\n');
+          updates.push(item.regex.source.includes('Author URI') ? 'Author URI' : 'Plugin URI');
+          return;
+        }
+      }
+      if (insertAfterIndex !== -1) {
+        lines.splice(insertAfterIndex + 1, 0, ` * Plugin URI: ${AUTHOR.uri}`);
+        content = lines.join('\n');
+        updates.push('Plugin URI');
+        return;
+      }
+    }
+    const newContent = content.replace(item.regex, `$1${item.value}`);
+    if (newContent !== content) {
+      const label = item.regex.source.includes('Description')
+        ? 'Description'
+        : item.regex.source.includes('Author URI')
+          ? 'Author URI'
+          : item.regex.source.includes('Author')
+            ? 'Author'
+            : item.regex.source.includes('Plugin URI')
+              ? 'Plugin URI'
+              : 'Plugin Name';
+      updates.push(label);
+      content = newContent;
+    }
+  });
+
+  const docblockRegex = /@author\s+.+/;
+  const linkRegex = /@link\s+.+/;
+  if (!docblockRegex.test(content)) {
+    content = content.replace(
+      /class\s+CV_Dossier_Context\s+\{/, 
+      '/**\n * Core plugin functionality for CV Dossier & Context.\n *\n * @author Francesco Passeri\n * @link https://francescopasseri.com\n */\nclass CV_Dossier_Context {'
+    );
+    updates.push('Class docblock');
+  } else {
+    const newContent = content
+      .replace(docblockRegex, '@author Francesco Passeri')
+      .replace(linkRegex, '@link https://francescopasseri.com');
+    if (newContent !== content) {
+      updates.push('Docblock metadata');
+      content = newContent;
+    }
+  }
+
+  if (updates.length === 0) {
+    return;
+  }
+
+  if (writeFile(filePath, original, content)) {
+    targets.push({ file: 'cv-dossier-context.php', fields: updates });
+  }
+}
+
+function ensureComposerJson() {
+  const filePath = path.join(ROOT, 'composer.json');
+  const original = readFile(filePath);
+  const data = JSON.parse(original);
+  let changed = false;
+
+  const desiredDescription = SHORT_DESCRIPTION;
+  if (data.description !== desiredDescription) {
+    data.description = desiredDescription;
+    changed = true;
+  }
+  if (data.homepage !== AUTHOR.uri) {
+    data.homepage = AUTHOR.uri;
+    changed = true;
+  }
+  if (!data.support) {
+    data.support = {};
+  }
+  if (data.support.issues !== AUTHOR.uri) {
+    data.support.issues = AUTHOR.uri;
+    changed = true;
+  }
+  const desiredAuthor = {
+    name: AUTHOR.name,
+    email: AUTHOR.email,
+    homepage: AUTHOR.uri,
+    role: 'Developer',
+  };
+  if (!Array.isArray(data.authors) || data.authors.length === 0) {
+    data.authors = [desiredAuthor];
+    changed = true;
+  } else {
+    const first = data.authors[0];
+    if (
+      first.name !== desiredAuthor.name ||
+      first.email !== desiredAuthor.email ||
+      first.homepage !== desiredAuthor.homepage ||
+      first.role !== desiredAuthor.role
+    ) {
+      data.authors[0] = desiredAuthor;
+      changed = true;
+    }
+  }
+
+  const ensureScript = (name, command) => {
+    if (!data.scripts) {
+      data.scripts = {};
+    }
+    const existing = data.scripts[name];
+    if (!existing || JSON.stringify(existing) !== JSON.stringify([command])) {
+      data.scripts[name] = [command];
+      changed = true;
+    }
+  };
+
+  ensureScript('sync:author', 'node tools/sync-author-metadata.js --apply=${APPLY:-false}');
+  ensureScript('sync:docs', 'node tools/sync-author-metadata.js --docs --apply=${APPLY:-false}');
+  ensureScript('changelog:from-git', 'npx --yes conventional-changelog-cli -p angular -i CHANGELOG.md -s');
+
+  if (!changed) {
+    return;
+  }
+
+  const updated = `${JSON.stringify(data, null, 2)}\n`;
+  if (writeFile(filePath, original, updated)) {
+    targets.push({ file: 'composer.json', fields: ['authors', 'homepage', 'support', 'scripts', 'description'] });
+  }
+}
+
+function ensureReadmeMd() {
+  const filePath = path.join(ROOT, 'README.md');
+  const original = readFile(filePath);
+  let content = original;
+  const replacements = [
+    { regex: /\| \*\*Author\*\* \| \[[^\]]+\]\([^\)]+\) \|/g, value: `| **Author** | [${AUTHOR.name}](${AUTHOR.uri}) |` },
+    { regex: /\| \*\*Requires WordPress\*\* \| [^|]+ \|/g, value: '| **Requires WordPress** | 6.0 |' },
+    { regex: /\| \*\*Tested up to\*\* \| [^|]+ \|/g, value: '| **Tested up to** | 6.4 |' },
+    { regex: /\| \*\*Requires PHP\*\* \| [^|]+ \|/g, value: '| **Requires PHP** | 8.0 |' },
+    { regex: /## What it does\n\n[^\n]+\n/, value: `## What it does\n\n${SHORT_DESCRIPTION}\n` },
+  ];
+
+  replacements.forEach(({ regex, value }) => {
+    content = content.replace(regex, value);
+  });
+
+  if (content === original) {
+    return;
+  }
+
+  if (writeFile(filePath, original, content)) {
+    targets.push({ file: 'README.md', fields: ['metadata table', 'short description'] });
+  }
+}
+
+function ensureReadmeTxt() {
+  const filePath = path.join(ROOT, 'readme.txt');
+  const original = readFile(filePath);
+  let content = original;
+  const map = new Map([
+    ['Contributors', 'franpass87, francescopasseri'],
+    ['Tags', 'dossier, timeline, map, journalism, follow-up'],
+    ['Requires at least', '6.0'],
+    ['Tested up to', '6.4'],
+    ['Requires PHP', '8.0'],
+    ['Stable tag', '1.0.2'],
+    ['License', 'GPLv2 or later'],
+    ['License URI', 'https://www.gnu.org/licenses/gpl-2.0.html'],
+  ]);
+
+  map.forEach((value, key) => {
+    const regex = new RegExp(`^${key}:.*$`, 'm');
+    content = content.replace(regex, `${key}: ${value}`);
+  });
+
+  content = content.replace(/^(Gestisce dossier[^\n]*)/m, SHORT_DESCRIPTION);
+
+  if (content === original) {
+    return;
+  }
+
+  if (writeFile(filePath, original, content)) {
+    targets.push({ file: 'readme.txt', fields: ['header fields', 'short description'] });
+  }
+}
+
+function ensureDocs() {
+  if (!DOCS_FLAG) {
+    return;
+  }
+  const overviewPath = path.join(ROOT, 'docs', 'overview.md');
+  if (fs.existsSync(overviewPath)) {
+    const original = readFile(overviewPath);
+    const updated = original.replace(
+      /(#[^\n]+\n\n)([^\n]+\n)/,
+      `$1${SHORT_DESCRIPTION}\n`
+    );
+    if (updated !== original && writeFile(overviewPath, original, updated)) {
+      targets.push({ file: 'docs/overview.md', fields: ['short description'] });
+    }
+  }
+}
+
+try {
+  ensurePluginHeader();
+  ensureComposerJson();
+  ensureReadmeMd();
+  ensureReadmeTxt();
+  ensureDocs();
+
+  if (targets.length === 0) {
+    console.log('No changes required.');
+    process.exit(0);
+  }
+
+  const tableHeader = ['File', 'Aggiornamenti'];
+  const rows = targets.map((entry) => [entry.file, entry.fields.join(', ')]);
+  const widths = [
+    Math.max(tableHeader[0].length, ...rows.map((r) => r[0].length)),
+    Math.max(tableHeader[1].length, ...rows.map((r) => r[1].length)),
+  ];
+
+  const renderRow = (cols) => `| ${cols[0].padEnd(widths[0])} | ${cols[1].padEnd(widths[1])} |`;
+  const separator = `|-${'-'.repeat(widths[0])}-|- ${'-'.repeat(widths[1])}-|`;
+
+  console.log(renderRow(tableHeader));
+  console.log(separator);
+  rows.forEach((row) => console.log(renderRow(row)));
+
+  process.exit(0);
+} catch (error) {
+  console.error(error);
+  process.exit(1);
+}

--- a/wp-content/plugins/cv-dossier-context/tools/sync-author-metadata.js
+++ b/wp-content/plugins/cv-dossier-context/tools/sync-author-metadata.js
@@ -179,7 +179,11 @@ function ensureComposerJson() {
       data.scripts = {};
     }
     const existing = data.scripts[name];
-    if (!existing || JSON.stringify(existing) !== JSON.stringify([command])) {
+    if (
+      !Array.isArray(existing) ||
+      existing.length !== 1 ||
+      existing[0] !== command
+    ) {
       data.scripts[name] = [command];
       changed = true;
     }

--- a/wp-content/plugins/cv-dossier-context/tools/sync-author-metadata.js
+++ b/wp-content/plugins/cv-dossier-context/tools/sync-author-metadata.js
@@ -2,11 +2,26 @@
 /* eslint-disable no-console */
 const fs = require('fs');
 const path = require('path');
+const yargs = require('yargs/yargs');
+const { hideBin } = require('yargs/helpers');
 
-const APPLY_FLAG = process.argv.find((arg) => arg.startsWith('--apply='));
-const DOCS_FLAG = process.argv.includes('--docs');
-const APPLY = APPLY_FLAG ? APPLY_FLAG.split('=')[1] === 'true' : false;
+const argv = yargs(hideBin(process.argv))
+  .option('apply', {
+    type: 'boolean',
+    description: 'Apply changes',
+    default: false,
+  })
+  .option('docs', {
+    type: 'boolean',
+    description: 'Show documentation',
+    default: false,
+  })
+  .help(false)
+  .version(false)
+  .argv;
 
+const APPLY = argv.apply;
+const DOCS_FLAG = argv.docs;
 const AUTHOR = {
   name: 'Francesco Passeri',
   email: 'info@francescopasseri.com',


### PR DESCRIPTION
## Summary
- align the plugin header, composer metadata, and both readme files with Francesco Passeri and the refreshed short description
- add structured README/readme documentation, a Keep a Changelog file, and detailed docs pages covering overview, architecture, and FAQ
- introduce a reusable Node sync script plus composer helpers for metadata/doc updates and changelog generation

## Testing
- php -l wp-content/plugins/cv-dossier-context/cv-dossier-context.php
- node tools/sync-author-metadata.js


------
https://chatgpt.com/codex/tasks/task_e_68de44ff0dcc832fa7e0fc3b786f1ed1